### PR TITLE
Reprocess bulk source tarballs which failed

### DIFF
--- a/arxiv_vanity/papers/models.py
+++ b/arxiv_vanity/papers/models.py
@@ -407,6 +407,14 @@ class SourceFileBulkTarball(models.Model):
     def __str__(self):
         return self.filename
 
+    def has_correct_number_of_files(self):
+        """
+        Number of items specified in the manifest matches how many we have
+        in the database. If this is false, it suggests there was some error
+        in downloading source files.
+        """
+        return self.num_items == self.sourcefile_set.count()
+
 
 class SourceFileQuerySet(models.QuerySet):
     def filename_exists(self, fn):

--- a/arxiv_vanity/papers/tests/test_models.py
+++ b/arxiv_vanity/papers/tests/test_models.py
@@ -1,8 +1,8 @@
 import datetime
 from django.test import TestCase
 from django.utils import timezone
-from ..models import guess_extension_from_headers, Render
-from .utils import create_paper, create_render
+from ..models import guess_extension_from_headers, Render, SourceFile
+from .utils import create_paper, create_render, create_source_file_bulk_tarball
 
 
 class PaperTest(TestCase):
@@ -75,3 +75,12 @@ class RenderTest(TestCase):
         qs = Render.objects.not_expired()
         self.assertNotIn(render1, qs)
         self.assertIn(render2, qs)
+
+
+class SourceFileBulkTarballTest(TestCase):
+    def test_has_correct_number_of_items(self):
+        tarball = create_source_file_bulk_tarball(num_items=2)
+        SourceFile.objects.create(file="1.gz", bulk_tarball=tarball)
+        self.assertFalse(tarball.has_correct_number_of_files())
+        SourceFile.objects.create(file="2.gz", bulk_tarball=tarball)
+        self.assertTrue(tarball.has_correct_number_of_files())

--- a/arxiv_vanity/papers/tests/utils.py
+++ b/arxiv_vanity/papers/tests/utils.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import uuid
 from django.conf import settings
-from ..models import Paper, Render
+from ..models import Paper, Render, SourceFileBulkTarball
 
 
 def create_paper(arxiv_id=None, title=None, updated=None, source_file=None,
@@ -52,3 +52,18 @@ def create_render_with_html(paper=None):
     os.makedirs(output_dir)
     shutil.copyfile(source_path, os.path.join(output_dir, 'index.html'))
     return render
+
+
+def create_source_file_bulk_tarball(num_items=None):
+    return SourceFileBulkTarball.objects.create(
+        filename="abc.tar",
+        content_md5sum="edd8c013a86b474a9a934ecf673f479e",
+        first_item="1111.2222",
+        last_item="3333.4444",
+        md5sum="af3a3f12f56feacb3c188cf262802a97",
+        num_items=num_items if num_items is not None else 5,
+        seq_num=3,
+        size=2345678,
+        timestamp="2000-01-01",
+        yymm="0001"
+    )

--- a/arxiv_vanity/scraper/bulk_sources.py
+++ b/arxiv_vanity/scraper/bulk_sources.py
@@ -23,11 +23,17 @@ def update_bulk_sources():
         # We've already processed this file, skip.
         # TODO: Re-process files which have been updated. (i.e. where md5 has
         # changed)
-        # TODO: Re-process files which have had errors in the past (number
-        # of actual is different from specified? a flag for success?)
-        if SourceFileBulkTarball.objects.filter(filename=f['filename']).exists():
-            print(f"Skipping {f['filename']}")
-            continue
+        try:
+            tarball = SourceFileBulkTarball.objects.get(filename=f['filename'])
+        except SourceFileBulkTarball.DoesNotExist:
+            # This is a new file
+            pass
+        else:
+            if tarball.has_correct_number_of_files():
+                print(f"Skipping {f['filename']}")
+                continue
+            else:
+                print(f"Reprocessing {f['filename']} because it has incorrect number of files")
 
         with tempfile.NamedTemporaryFile(suffix='tar') as tarfh:
 


### PR DESCRIPTION
If the number of items doesn't match the reported number
in the manifest, this is a pretty reliable indicator it failed.
Worst case, the tarball is reprocessed.