### PR TITLE
Retry removing container when it fails

### DIFF
--- a/arxiv_vanity/utils.py
+++ b/arxiv_vanity/utils.py
@@ -4,13 +4,17 @@ import os
 from raven.contrib.django.raven_compat.models import client
 
 
+def log_exception():
+    traceback.print_exc()
+    if os.environ.get('SENTRY_DSN'):
+        client.captureException()
+
+
 def catch_exceptions(f):
     @wraps(f)
     def inner(*args, **kwargs):
         try:
             return f(*args, **kwargs)
-        except Exception as e:
-            traceback.print_exc()
-            if os.environ.get('SENTRY_DSN'):
-                client.captureException()
+        except Exception:
+            log_exception()
     return inner


### PR DESCRIPTION
Hyper.sh throws 500s all the time when removing. Save the render
state before removing so nothing else breaks, then also ignore
errors when updating render state so we can actually remove them
eventually.