### PR TITLE
Make convert box remove version from id.

### DIFF
--- a/arxiv_vanity/papers/views.py
+++ b/arxiv_vanity/papers/views.py
@@ -140,6 +140,7 @@ def paper_convert(request):
         return render(request, "papers/paper_convert_error.html", {
             "message": "Could not find arXiv ID in that URL. Are you sure it's an arxiv.org URL?"
         })
+    arxiv_id, _ = remove_version_from_arxiv_id(arxiv_id)
     return redirect("paper_detail", arxiv_id=arxiv_id)
 
 


### PR DESCRIPTION
To avoid unnecessary redirect.

Fixes https://github.com/arxiv-vanity/arxiv-vanity/issues/132.