### PR TITLE
Instruct to build engrafo-dev image for development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Do the initial database migration and set up a user:
     $ script/manage migrate
     $ script/manage createsuperuser
 
+Build engrafo-dev docker image (needed for rendering papers):
+
+    $ docker build https://github.com/arxiv-vanity/engrafo.git -t engrafo-dev
+
 Then to run the app:
 
     $ docker-compose up --build


### PR DESCRIPTION
Otherwise, the app crashes as soon as user tries to render a paper or when user tries to run the scrape_papers script.

I'm not sure though where the `engrafo-dev` image should come from, I assumed it's the latest build of the docker image from engrafo repository.

An alternative to this would be to use engrafo's public image for the development of arxiv-vanity. This approach would loosen the coupling between engrafo and arxiv-vanity.