### PR TITLE
Support legacy arXiv IDs.

### DIFF
--- a/arxiv_vanity/papers/downloader.py
+++ b/arxiv_vanity/papers/downloader.py
@@ -39,6 +39,17 @@ def arxiv_id_to_source_url(arxiv_id):
     return 'https://arxiv.org/e-print/' + arxiv_id
 
 
+def arxiv_id_to_source_file(arxiv_id):
+    """
+    Convert an arXiv ID into the filename the source file should be stored as,
+    without extension.
+
+    This is the inverse of `convert_source_file_to_arxiv_id()` in 
+    `arxiv_vanity/scraper/bulk_sources.py`.
+    """
+    return arxiv_id.replace("/", "")
+
+
 def download_source_file(arxiv_id):
     """
     Download the LaTeX source of this paper and returns as ContentFile.
@@ -54,5 +65,5 @@ def download_source_file(arxiv_id):
                                 res.headers.get('content-type'),
                                 res.headers.get('content-encoding')))
     file = ContentFile(res.content)
-    file.name = arxiv_id + extension
+    file.name = arxiv_id_to_source_file(arxiv_id) + extension
     return file

--- a/arxiv_vanity/papers/processor.py
+++ b/arxiv_vanity/papers/processor.py
@@ -1,5 +1,4 @@
 from bs4 import BeautifulSoup
-from django.template.loader import render_to_string
 import os
 
 

--- a/arxiv_vanity/papers/renderer.py
+++ b/arxiv_vanity/papers/renderer.py
@@ -4,7 +4,6 @@ import shlex
 import docker
 from docker.tls import TLSConfig
 from django.conf import settings
-import dateutil.parser
 import tempfile
 from ..utils import log_exception
 

--- a/arxiv_vanity/papers/tests/test_views.py
+++ b/arxiv_vanity/papers/tests/test_views.py
@@ -124,6 +124,7 @@ class TestPaperConvert(TestCase):
     def test_convert_query_to_arxiv_id(self):
         # arxiv URLs
         self.assertEqual(convert_query_to_arxiv_id('http://arxiv.org/abs/1709.04466v1'), '1709.04466v1')
+        self.assertEqual(convert_query_to_arxiv_id('http://arxiv.org/abs/astro-ph/0601001'), 'astro-ph/0601001')
         self.assertEqual(convert_query_to_arxiv_id('http://arXiv.org/abs/1709.04466v1'), '1709.04466v1')
         self.assertEqual(convert_query_to_arxiv_id('https://arxiv.org/abs/1709.04466v1'), '1709.04466v1')
         self.assertEqual(convert_query_to_arxiv_id('http://arxiv.org/pdf/1709.04466v1'), '1709.04466v1')
@@ -134,6 +135,7 @@ class TestPaperConvert(TestCase):
         # arxiv IDs
         self.assertEqual(convert_query_to_arxiv_id('1709.04466'), '1709.04466')
         self.assertEqual(convert_query_to_arxiv_id('1709.04466v1'), '1709.04466v1')
+        self.assertEqual(convert_query_to_arxiv_id('astro-ph/0601001v1'), 'astro-ph/0601001v1')
         self.assertEqual(convert_query_to_arxiv_id('arxiv:1709.04466'), '1709.04466')
         self.assertEqual(convert_query_to_arxiv_id('arXiv:1709.04466'), '1709.04466')
 

--- a/arxiv_vanity/papers/views.py
+++ b/arxiv_vanity/papers/views.py
@@ -8,7 +8,7 @@ from django.utils.cache import add_never_cache_headers, patch_cache_control
 from django.views.decorators.cache import cache_control, never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from django.views.generic import ListView, TemplateView
+from django.views.generic import TemplateView
 from .models import Paper, Render, PaperIsNotRenderableError
 from ..scraper.arxiv_ids import remove_version_from_arxiv_id
 from ..scraper.query import PaperNotFoundError

--- a/arxiv_vanity/papers/views.py
+++ b/arxiv_vanity/papers/views.py
@@ -10,7 +10,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 from .models import Paper, Render, PaperIsNotRenderableError
-from ..scraper.arxiv_ids import remove_version_from_arxiv_id
+from ..scraper.arxiv_ids import remove_version_from_arxiv_id, ARXIV_ID_PATTERN
 from ..scraper.query import PaperNotFoundError
 
 
@@ -116,9 +116,9 @@ def render_update_state(request, pk):
     return HttpResponse()
 
 
-ARXIV_URL_RE = re.compile(r'arxiv.org/[^\/]+/([\w\.]+?)(\.pdf)?$', re.I)
-ARXIV_DOI_RE = re.compile(r'^(?:arxiv:)?(\d+\.\d+(?:v\d+)?)$', re.I)
-ARXIV_VANITY_RE = re.compile(r'(?:localhost\:\d+|arxiv-vanity\.com)/[^\/]+/([\w\.]+?)\/?$', re.I)
+ARXIV_URL_RE = re.compile(fr'arxiv.org/[^\/]+/({ARXIV_ID_PATTERN})(\.pdf)?$', re.I)
+ARXIV_DOI_RE = re.compile(fr'^(?:arxiv:)?({ARXIV_ID_PATTERN})$', re.I)
+ARXIV_VANITY_RE = re.compile(fr'(?:localhost\:\d+|arxiv-vanity\.com)/[^\/]+/({ARXIV_ID_PATTERN})\/?$', re.I)
 
 
 def convert_query_to_arxiv_id(query):

--- a/arxiv_vanity/papers/views.py
+++ b/arxiv_vanity/papers/views.py
@@ -117,13 +117,13 @@ def render_update_state(request, pk):
 
 
 ARXIV_URL_RE = re.compile(r'arxiv.org/[^\/]+/([\w\.]+?)(\.pdf)?$', re.I)
-ARXIV_ID_RE = re.compile(r'^(?:arxiv:)?(\d+\.\d+(?:v\d+)?)$', re.I)
+ARXIV_DOI_RE = re.compile(r'^(?:arxiv:)?(\d+\.\d+(?:v\d+)?)$', re.I)
 ARXIV_VANITY_RE = re.compile(r'(?:localhost\:\d+|arxiv-vanity\.com)/[^\/]+/([\w\.]+?)\/?$', re.I)
 
 
 def convert_query_to_arxiv_id(query):
     query = query.strip()
-    for regex in [ARXIV_URL_RE, ARXIV_ID_RE, ARXIV_VANITY_RE]:
+    for regex in [ARXIV_URL_RE, ARXIV_DOI_RE, ARXIV_VANITY_RE]:
         match = regex.search(query)
         if match:
             return match.group(1)

--- a/arxiv_vanity/scraper/arxiv_ids.py
+++ b/arxiv_vanity/scraper/arxiv_ids.py
@@ -1,6 +1,6 @@
 import re
 
-ARXIV_ID_PATTERN = r'(\d+\.\d+)(v\d+)?'
+ARXIV_ID_PATTERN = r'([a-z\-]+(?:\.[A-Z]{2})?/\d{7}|\d+\.\d+)(v\d+)?'
 ARXIV_ID_RE = re.compile(ARXIV_ID_PATTERN)
 
 

--- a/arxiv_vanity/scraper/arxiv_ids.py
+++ b/arxiv_vanity/scraper/arxiv_ids.py
@@ -1,13 +1,12 @@
 import re
 
-ARXIV_ID_RE = re.compile(r'^(.+?)v(\d+)$')
+ARXIV_ID_PATTERN = r'(\d+\.\d+)(v\d+)?'
+ARXIV_ID_RE = re.compile(ARXIV_ID_PATTERN)
 
 
 def remove_version_from_arxiv_id(arxiv_id):
     match = ARXIV_ID_RE.match(arxiv_id)
-    if not match:
-        return arxiv_id, None
-    return match.group(1), int(match.group(2))
+    return match.group(1), int(match.group(2)[1:]) if match.group(2) else None
 
 
 ARXIV_URL_RE = re.compile(r'v(\d+)$')

--- a/arxiv_vanity/scraper/query.py
+++ b/arxiv_vanity/scraper/query.py
@@ -3,7 +3,7 @@ from xml.etree import ElementTree
 import dateutil.parser
 import requests
 
-from .arxiv_ids import remove_version_from_arxiv_id, remove_version_from_arxiv_url
+from .arxiv_ids import remove_version_from_arxiv_id, remove_version_from_arxiv_url, ARXIV_ID_RE
 
 ROOT_URL = 'http://export.arxiv.org/api/'
 NS = {
@@ -90,7 +90,7 @@ def convert_entry_to_paper(entry):
     with.
     """
     d = {}
-    d['arxiv_id'] = entry.find("atom:id", NS).text.split('/')[-1]
+    d['arxiv_id'] = ARXIV_ID_RE.search(entry.find("atom:id", NS).text).group()
     d['title'] = entry.find("atom:title", NS).text
     d['title'] = d['title'].replace('\n', '').replace('  ', ' ')
     d['published'] = dateutil.parser.parse(

--- a/arxiv_vanity/scraper/tests/test_arxiv_ids.py
+++ b/arxiv_vanity/scraper/tests/test_arxiv_ids.py
@@ -10,3 +10,9 @@ class ArxivIdsTest(TestCase):
 
         id, version = remove_version_from_arxiv_id("1709.09354")
         self.assertEqual((id, version), ("1709.09354", None))
+
+        id, version = remove_version_from_arxiv_id("astro-ph/0601001")
+        self.assertEqual((id, version), ("astro-ph/0601001", None))
+
+        id, version = remove_version_from_arxiv_id("astro-ph/0601001v402")
+        self.assertEqual((id, version), ("astro-ph/0601001", 402))

--- a/arxiv_vanity/scraper/tests/test_arxiv_ids.py
+++ b/arxiv_vanity/scraper/tests/test_arxiv_ids.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+from ..arxiv_ids import remove_version_from_arxiv_id
+
+
+class ArxivIdsTest(TestCase):
+
+    def test_remove_version_from_arxiv_id(self):
+        id, version = remove_version_from_arxiv_id("1709.09354v1")
+        self.assertEqual((id, version), ("1709.09354", 1))
+
+        id, version = remove_version_from_arxiv_id("1709.09354")
+        self.assertEqual((id, version), ("1709.09354", None))

--- a/arxiv_vanity/tests/test_urls.py
+++ b/arxiv_vanity/tests/test_urls.py
@@ -1,0 +1,15 @@
+from django.urls import resolve
+from django.test import TestCase
+
+
+class UrlsTest(TestCase):
+
+    def test_urls(self):
+        resolver = resolve('/papers/1703.07815/')
+        self.assertEquals(resolver.view_name, 'paper_detail')
+
+        resolver = resolve('/pdf/1703.07815/')
+        self.assertEquals(resolver.view_name, 'django.views.generic.base.RedirectView')
+
+        resolver = resolve('/papers/1703.07815/render-state/')
+        self.assertEquals(resolver.view_name, 'paper_render_state')

--- a/arxiv_vanity/tests/test_urls.py
+++ b/arxiv_vanity/tests/test_urls.py
@@ -13,3 +13,9 @@ class UrlsTest(TestCase):
 
         resolver = resolve('/papers/1703.07815/render-state/')
         self.assertEquals(resolver.view_name, 'paper_render_state')
+
+        resolver = resolve('/papers/astro-ph/0601001/')
+        self.assertEquals(resolver.view_name, 'paper_detail')
+
+        resolver = resolve('/papers/astro-ph/0601001/render-state/')
+        self.assertEquals(resolver.view_name, 'paper_render_state')

--- a/arxiv_vanity/urls.py
+++ b/arxiv_vanity/urls.py
@@ -10,14 +10,15 @@ from django.urls import path, re_path
 from django.views.generic.base import TemplateView, RedirectView
 from .feedback.views import submit_feedback
 from .papers.views import HomeView, paper_detail, paper_convert, paper_render_state, render_update_state, stats
+from .scraper.arxiv_ids import ARXIV_ID_PATTERN
 
 urlpatterns = [
     path('', HomeView.as_view(), name='home'),
-    path('papers/<arxiv_id>/', paper_detail, name='paper_detail'),
-    path('abs/<arxiv_id>/', RedirectView.as_view(pattern_name='paper_detail')),
-    path('format/<arxiv_id>/', RedirectView.as_view(pattern_name='paper_detail')),
-    re_path(r'pdf/(?P<arxiv_id>.*?)(\.pdf)?/', RedirectView.as_view(pattern_name='paper_detail')),
-    path('papers/<arxiv_id>/render-state/', paper_render_state, name='paper_render_state'),
+    re_path(fr'papers/(?P<arxiv_id>{ARXIV_ID_PATTERN})/$', paper_detail, name='paper_detail'),
+    re_path(fr'abs/(?P<arxiv_id>{ARXIV_ID_PATTERN})/', RedirectView.as_view(pattern_name='paper_detail')),
+    re_path(fr'format/(?P<arxiv_id>{ARXIV_ID_PATTERN})/', RedirectView.as_view(pattern_name='paper_detail')),
+    re_path(fr'pdf/(?P<arxiv_id>{ARXIV_ID_PATTERN})(\.pdf)?/', RedirectView.as_view(pattern_name='paper_detail')),
+    re_path(fr'papers/(?P<arxiv_id>{ARXIV_ID_PATTERN})/render-state/', paper_render_state, name='paper_render_state'),
     path('renders/<int:pk>/update-state/', render_update_state, name='render_update_state'),
     path('convert/', paper_convert, name='paper_convert'),
     path('submit-feedback/', submit_feedback),


### PR DESCRIPTION
This fixes https://github.com/arxiv-vanity/arxiv-vanity/issues/69. 

The actual change (01613fb) is trivial, but it had to be preceded by a series of small refactors which ensure that arXiv ID regex is used more consistently across the codebase. 

Unfortunately, looks like none of the papers linked in the issue can be rendered at the moment, but it can be tested with another paper, e.g. http://arxiv.org/abs/astro-ph/0601001 . 