### PR TITLE
Don't ignore content-encoding for tex file source.

### DIFF
--- a/arxiv_vanity/papers/downloader.py
+++ b/arxiv_vanity/papers/downloader.py
@@ -19,10 +19,8 @@ def guess_extension_from_headers(h):
         return '.ps.gz'
     if h.get('content-encoding') == 'x-gzip' and h.get('content-type') == 'application/x-eprint-tar':
         return '.tar.gz'
-    # content-encoding is x-gzip but this appears to normally be a lie - it's
-    # just plain text
-    if h.get('content-type') == 'application/x-eprint':
-        return '.tex'
+    if h.get('content-encoding') == 'x-gzip' and h.get('content-type') == 'application/x-eprint':
+        return '.tex.gz'
     if h.get('content-encoding') == 'x-gzip' and h.get('content-type') == 'application/x-dvi':
         return '.dvi.gz'
     return None

--- a/arxiv_vanity/papers/tests/test_downloader.py
+++ b/arxiv_vanity/papers/tests/test_downloader.py
@@ -21,7 +21,7 @@ class DownloaderTest(unittest.TestCase):
         self.assertEqual(guess_extension_from_headers({
             'content-encoding': 'x-gzip',
             'content-type': 'application/x-eprint',
-        }), '.tex')
+        }), '.tex.gz')
         self.assertEqual(guess_extension_from_headers({
             'content-encoding': 'x-gzip',
             'content-type': 'application/x-dvi',


### PR DESCRIPTION
Resolves https://github.com/arxiv-vanity/arxiv-vanity/issues/325 .

The comment in the code was suggesting that arXiv returns a plain text file even when the `content-encoding` header was `x-gzip`. It looks like this is no longer true, at least not for the two papers mentioned in the related issue.

Perhaps  arXiv fixed this behaviour (for newer papers). 