### PR TITLE
Add examples of valid arXiv URLs.

### DIFF
--- a/arxiv_vanity/static/css/main.css
+++ b/arxiv_vanity/static/css/main.css
@@ -87,6 +87,13 @@ html, body {
   max-width: 800px;
 }
 
+.urls-example-list {
+    list-style: none;
+    padding-left: 0;
+    margin-bottom: 10px;
+    font-size: smaller;
+}
+
 .page-container {
   margin-top: 4rem;
   margin-bottom: 4rem;

--- a/arxiv_vanity/templates/papers/paper_convert_error.html
+++ b/arxiv_vanity/templates/papers/paper_convert_error.html
@@ -5,6 +5,13 @@
   <div class="arxiv-vanity-wrapper paper-detail-status">
     <div class="paper-detail-status-inner">
       <p>{{ message }}</p>
+      <p>Here are some examples of supported arXiv URLs:</p>
+      <ul class="urls-example-list">
+        <li>https://arxiv.org/abs/1709.04466</li>
+        <li>https://arxiv.org/pdf/1904.08653.pdf</li>
+        <li>arxiv:1503.02531</li>
+      </ul>
+      </p>
       <p><a href="/">Go back home</a></p>
     </div>
   </div>


### PR DESCRIPTION
Resolves https://github.com/arxiv-vanity/arxiv-vanity/issues/382.

Preview of the error page with added examples: 

<img width="944" alt="Screenshot 2019-05-12 at 18 13 53" src="https://user-images.githubusercontent.com/7057316/57586345-f1423100-74f4-11e9-87c4-9e425002cab2.png">
