### PR TITLE
Wrap paper body in a semantic tag for Reader mode

### DIFF
--- a/arxiv_vanity/templates/papers/paper_detail.html
+++ b/arxiv_vanity/templates/papers/paper_detail.html
@@ -36,7 +36,9 @@
 
 {% endblock %}
 {% block content %}
-  {{ body|safe }}
+  <article>
+    {{ body|safe }}
+  </article>
 
 <div class="arxiv-vanity-wrapper">
   <div class="container">


### PR DESCRIPTION
Hey folks, big fan of this tool — i use it often!

One small pain point I’ve run into is occasionally preferring Reader mode for strangly formatted documents — but it only seems to pick up the abstract currently!

I wanted to see if I could enable browser Reader features for the full paper, not just the abstract. I referenced this post to inform my change to wrap the body in an `<article>` tag:
> Use the right markup, i.e. make sure the most important content is wrapped inside a container element. Whether you use `<article>`, `<div>` or even `<span>` doesn’t seem to matter — as long as it’s not `<p>`.

https://mathiasbynens.be/notes/safari-reader

Apologies if there are other contribution expectations — I couldn’t find any kind of documentation to that effect, but I’m happy to do whatever you all deem necessary if anything!